### PR TITLE
修复重复调用工具时出现的"Target page, context or browser has been closed"bug

### DIFF
--- a/src/auth/authManager.ts
+++ b/src/auth/authManager.ts
@@ -44,12 +44,11 @@ export class AuthManager {
   }
 
   async getBrowser(): Promise<Browser> {
-    if (!this.browser) {
-      logger.info('Launching browser');
-      this.browser = await chromium.launch({
-        headless: false,
-      });
-    }
+    logger.info('Launching browser');
+    // 始终创建新的浏览器实例，不复用之前的
+    this.browser = await chromium.launch({
+      headless: false,
+    });
     return this.browser;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,8 +12,6 @@ import { createStdioLogger } from './utils/stdioLogger'
 
 const execAsync = promisify(exec)
 
-const tools = new RedNoteTools()
-
 const name = 'rednote'
 const description =
   'A friendly tool to help you access and interact with Xiaohongshu (RedNote) content through Model Context Protocol.'
@@ -44,6 +42,7 @@ server.tool(
   async ({ keywords, limit = 10 }: { keywords: string; limit?: number }) => {
     logger.info(`Searching notes with keywords: ${keywords}, limit: ${limit}`)
     try {
+      const tools = new RedNoteTools()
       const notes = await tools.searchNotes(keywords, limit)
       logger.info(`Found ${notes.length} notes`)
       return {
@@ -68,6 +67,7 @@ server.tool(
   async ({ url }: { url: string }) => {
     logger.info(`Getting note content for URL: ${url}`)
     try {
+      const tools = new RedNoteTools()
       const note = await tools.getNoteContent(url)
       logger.info(`Successfully retrieved note: ${note.title}`)
 
@@ -95,6 +95,7 @@ server.tool(
   async ({ url }: { url: string }) => {
     logger.info(`Getting comments for URL: ${url}`)
     try {
+      const tools = new RedNoteTools()
       const comments = await tools.getNoteComments(url)
       logger.info(`Found ${comments.length} comments`)
       return {

--- a/src/tools/rednoteTools.ts
+++ b/src/tools/rednoteTools.ts
@@ -33,10 +33,14 @@ export class RedNoteTools {
 
   async initialize(): Promise<void> {
     logger.info('Initializing browser and page')
+    this.browser = await this.authManager.getBrowser()
     if (!this.browser) {
-      this.browser = await this.authManager.getBrowser()
+      throw new Error('Failed to initialize browser')
+    }
+    
+    try {
       this.page = await this.browser.newPage()
-
+      
       // Load cookies if available
       const cookies = await this.authManager.getCookies()
       if (cookies.length > 0) {
@@ -58,15 +62,30 @@ export class RedNoteTools {
         throw new Error('Not logged in')
       }
       logger.info('Login status verified')
+    } catch (error) {
+      // 初始化过程中出错，确保清理资源
+      await this.cleanup()
+      throw error
     }
   }
 
   async cleanup(): Promise<void> {
     logger.info('Cleaning up browser resources')
-    if (this.browser) {
-      await this.browser.close()
-      this.browser = null
+    try {
+      if (this.page) {
+        await this.page.close().catch(err => logger.error('Error closing page:', err))
+        this.page = null
+      }
+      
+      if (this.browser) {
+        await this.browser.close().catch(err => logger.error('Error closing browser:', err))
+        this.browser = null
+      }
+    } catch (error) {
+      logger.error('Error during cleanup:', error)
+    } finally {
       this.page = null
+      this.browser = null
     }
   }
 
@@ -92,10 +111,10 @@ export class RedNoteTools {
 
   async searchNotes(keywords: string, limit: number = 10): Promise<Note[]> {
     logger.info(`Searching notes with keywords: ${keywords}, limit: ${limit}`)
-    await this.initialize()
-    if (!this.page) throw new Error('Page not initialized')
-
     try {
+      await this.initialize()
+      if (!this.page) throw new Error('Page not initialized')
+
       // Navigate to search page
       logger.info('Navigating to search page')
       await this.page.goto(`https://www.xiaohongshu.com/search_result?keyword=${encodeURIComponent(keywords)}`)
@@ -206,6 +225,9 @@ export class RedNoteTools {
 
       logger.info(`Successfully processed ${notes.length} notes`)
       return notes
+    } catch (error) {
+      logger.error('Error searching notes:', error)
+      throw error
     } finally {
       await this.cleanup()
     }
@@ -213,12 +235,12 @@ export class RedNoteTools {
 
   async getNoteContent(url: string): Promise<NoteDetail> {
     logger.info(`Getting note content for URL: ${url}`)
-    await this.initialize()
-    if (!this.page) throw new Error('Page not initialized')
-
     try {
+      await this.initialize()
+      if (!this.page) throw new Error('Page not initialized')
+
       const actualURL = this.extractRedBookUrl(url)
-      await this.page.goto(url)
+      await this.page.goto(actualURL)
       let note = await GetNoteDetail(this.page)
       note.url = url
       logger.info(`Successfully extracted note: ${note.title}`)
@@ -233,10 +255,10 @@ export class RedNoteTools {
 
   async getNoteComments(url: string): Promise<Comment[]> {
     logger.info(`Getting comments for URL: ${url}`)
-    await this.initialize()
-    if (!this.page) throw new Error('Page not initialized')
-
     try {
+      await this.initialize()
+      if (!this.page) throw new Error('Page not initialized')
+
       await this.page.goto(url)
 
       // Wait for comments to load


### PR DESCRIPTION
1. RedNoteTools 类修改
initialize()方法改进:
每次都创建新的浏览器实例
添加错误处理，确保初始化失败时清理资源
分别关闭页面和浏览器，捕获可能的错误
统一方法调用结构:
修改了searchNotes、getNoteContent和getNoteComments方法
将try块移动到方法开头，包括initialize()调用
添加错误日志和错误传播
2. AuthManager 类修改
getBrowser()方法改进:
移除对this.browser的检查，不再复用已存在的实例
确保每次调用都创建并返回一个全新的浏览器实例
3. CLI 工具修改
移除全局单例工具实例:
删除顶部的全局RedNoteTools实例声明
为每个工具调用创建独立实例